### PR TITLE
Use env variable for site URL in Nuxt SEO config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,9 @@
 // nuxt.config.ts
 import { defineNuxtConfig } from "nuxt/config";
 
+// Definisikan URL situs Anda di sini, agar mudah diakses di seluruh konfigurasi
+// const SITE_URL = "https://www.gvanandita.com"; // GANTI DENGAN URL ASLI WEBSITE ANDA
+
 export default defineNuxtConfig({
   app: {
     head: {
@@ -33,30 +36,43 @@ export default defineNuxtConfig({
   },
   plugins: ["~/plugins/fontawesome.js", "~/plugins/aos.client.js"],
 
-  // --- Perubahan PENTING di sini ---
+  // --- Penyesuaian konfigurasi @nuxtjs/seo ---
   modules: [
-    ['@nuxtjs/seo', {
-      site: {
-        url: 'https://www.gvanandita.com', 
-        name: 'GV Anandita',
-        description: 'Solusi Pembiayaan Pensiun ASN, TNI, Polri.',
-        defaultLocale: 'id',
-        identity: {
-          type: 'Organization',
-          name: 'GV Anandita',
-          url: 'https://www.gvanandita.com',
-        }
+    [
+      "@nuxtjs/seo",
+      {
+        site: {
+          // Gunakan process.env.NUXT_PUBLIC_SITE_URL di sini
+          url: process.env.NUXT_PUBLIC_SITE_URL || "https://www.gvanandita.com", // Fallback jika .env tidak ada
+          name: "GV Anandita",
+          description: "Solusi Pembiayaan Pensiun ASN, TNI, Polri.",
+          defaultLocale: "id",
+          identity: {
+            type: "Organization",
+            name: "GV Anandita",
+            // Pastikan ini juga mengambil dari variabel lingkungan
+            url:
+              process.env.NUXT_PUBLIC_SITE_URL || "https://www.gvanandita.com",
+          },
+        },
+        sitemap: {
+          enabled: true,
+          // Penting: Pastikan hostname juga mengambil dari variabel lingkungan
+          hostname:
+            process.env.NUXT_PUBLIC_SITE_URL || "https://www.gvanandita.com",
+        },
+        robots: {
+          enabled: true,
+          rules: [{ UserAgent: "*" }, { Allow: "/" }],
+        },
       },
-      sitemap: {
-        enabled: true,
-      },
-      robots: {
-        enabled: true,
-        rules: [
-          { UserAgent: '*' },
-          { Allow: '/' },
-        ],
-      },
-    }],
+    ],
   ],
+
+  // Ini sudah benar, pastikan tetap ada untuk konsistensi di runtime
+  runtimeConfig: {
+    public: {
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || "https://www.gvanandita.com",
+    },
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5356,9 +5356,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.0.tgz",
+      "integrity": "sha512-Omf1L8paOy2VJhILjyhrhqwLIdstqm1BvcDPKg4NGAlkwEu9ODyrFbvk8UymUOMCT+HXo31jg1lArIrVAAhuGA==",
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
Updated the @nuxtjs/seo module configuration in nuxt.config.ts to use process.env.NUXT_PUBLIC_SITE_URL for the site URL, sitemap hostname, and identity URL, with a fallback to the default URL. This improves flexibility for different environments and centralizes site URL management.